### PR TITLE
remove deprecated dropdownPosition prop

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "deploy": "next build && next export && npx thirdweb@latest upload out"
   },
   "dependencies": {
-    "@thirdweb-dev/react": "^4",
+    "@thirdweb-dev/react": "^4.4",
     "@thirdweb-dev/sdk": "^4",
     "ethers": "^5",
     "next": "^13",

--- a/pages/index.js
+++ b/pages/index.js
@@ -27,12 +27,7 @@ export default function Home() {
           </p>
 
           <div className={styles.connect}>
-            <ConnectWallet
-              dropdownPosition={{
-                side: "bottom",
-                align: "center",
-              }}
-            />
+            <ConnectWallet />
           </div>
         </div>
 


### PR DESCRIPTION
A [recent update](https://github.com/thirdweb-dev/js/commit/212b2e7bc28c8e88207a9935756f7e6133a5b7d3) to the ConnectWallet component removed the dropdownPosition prop. 


This update removes the reference to the deprecated dropdownPosition prop in the ConnectWallet component.